### PR TITLE
fixes a bug that caused ctrl+a to misbehave

### DIFF
--- a/js/tinymce/classes/EditorCommands.js
+++ b/js/tinymce/classes/EditorCommands.js
@@ -794,7 +794,7 @@ define("tinymce/EditorCommands", [
 				if (selection.getRng().setStart) {
 					rng = dom.createRng();
 					rng.setStart(root, 0);
-					rng.setEnd(root, root.childNodes.length);
+					rng.setEndAfter(root, root.childNodes.length);
 					selection.setRng(rng);
 				} else {
 					// IE will render it's own root level block elements and sometimes


### PR DESCRIPTION
In Firefox, if the editor contains similar content to

    <body>
        <strong>First</strong> some text <br>
        <strong>Last</strong> other text
    </body>

then the tinymce command `selectAll` caused "other text" to not get selected, including when using the meta+a shortcuts. This fixed it for me.